### PR TITLE
random secret seed added to keepalived.authPassword

### DIFF
--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -12,5 +12,5 @@ data:
   {{- if .Values.keepalived.authPassword }}
   password: {{ .Values.keepalived.authPassword | b64enc }}
   {{- else }}
-  password: {{ printf "%s:%s" .Release.Name .Release.Namespace | sha256sum | trunc 8 | b64enc }}
+  password: {{ randAlphaNum 8 | b64enc }}
   {{- end }}


### PR DESCRIPTION
### Situation:
If `keepalived.authPassword` is not specified, `.Release.Name ` and `.Release.Namespace` are used as seed for the generation of the secret `keepalived-ingress-vip`. 

See Issue #5 

### Solution:
Use 
```
data:
  {{- if .Values.keepalived.authPassword }}
  password: {{ .Values.keepalived.authPassword | b64enc }}
  {{- else }}
  password: {{ randAlphaNum 8 | b64enc }}
  {{- end }}
```
in chart/templates/secret.yaml